### PR TITLE
remove the fd boxing

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -2,12 +2,13 @@ use futures::{try_ready, Async, Future, Poll};
 use std::io;
 use std::time::Duration;
 
+use crate::timerfd::TimerFd;
+
 /// A future that completes a specified amount of time from its creation.
 ///
 /// Instances of `Delay` perform no work and complete with `()` once the specified duration has been passed.
 pub struct Delay {
-    fd: Box<std::os::unix::io::RawFd>,
-    e: Option<tokio_reactor::PollEvented<mio::unix::EventedFd<'static>>>,
+    e: Option<tokio_reactor::PollEvented<TimerFd>>,
 }
 
 impl Delay {
@@ -15,21 +16,13 @@ impl Delay {
     pub fn new(delay: Duration) -> io::Result<Self> {
         if delay.as_secs() == 0 && delay.subsec_nanos() == 0 {
             // this would be interpreted as "inactive timer" by timerfd_settime
-            return Ok(Self {
-                fd: Box::new(0),
-                e: None,
-            });
+            return Ok(Self { e: None });
         }
 
         let tfd = unsafe { libc::timerfd_create(libc::CLOCK_MONOTONIC, libc::TFD_NONBLOCK) };
         if tfd == -1 {
             return Err(io::Error::last_os_error());
         }
-        let tfd = Box::new(tfd);
-        let mtfd = mio::unix::EventedFd(&*tfd);
-        let e = tokio_reactor::PollEvented::new(mtfd);
-        let e: tokio_reactor::PollEvented<mio::unix::EventedFd<'static>> =
-            unsafe { std::mem::transmute(e) };
 
         // arm the timer
         let timer = libc::itimerspec {
@@ -42,15 +35,15 @@ impl Delay {
                 tv_nsec: i64::from(delay.subsec_nanos()),
             },
         };
-        let ret = unsafe { libc::timerfd_settime(*tfd, 0, &timer, std::ptr::null_mut()) };
+        let ret = unsafe { libc::timerfd_settime(tfd, 0, &timer, std::ptr::null_mut()) };
         if ret == -1 {
             return Err(io::Error::last_os_error());
         }
 
-        Ok(Self {
-            fd: tfd,
-            e: Some(e),
-        })
+        let tfd = TimerFd(tfd);
+        let e = tokio_reactor::PollEvented::new(tfd);
+
+        Ok(Self { e: Some(e) })
     }
 }
 
@@ -67,14 +60,5 @@ impl Future for Delay {
         // we don't ever _actually_ need to read from a timerfd
         self.e.as_mut().unwrap().clear_read_ready(ready)?;
         Ok(Async::Ready(()))
-    }
-}
-
-impl Drop for Delay {
-    fn drop(&mut self) {
-        if let Some(e) = self.e.take() {
-            drop(e);
-            unsafe { libc::close(*self.fd) };
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 
 #![deny(missing_docs)]
 
+mod timerfd;
+
 mod delay;
 pub use delay::Delay;
 

--- a/src/timerfd.rs
+++ b/src/timerfd.rs
@@ -1,0 +1,45 @@
+use mio::unix::EventedFd;
+use mio::Evented;
+use mio::Poll;
+use mio::PollOpt;
+use mio::Ready;
+use mio::Token;
+use std::io;
+use std::os::unix::io::RawFd;
+
+pub(crate) struct TimerFd(pub RawFd);
+
+impl Evented for TimerFd {
+    fn register(
+        &self,
+        poll: &Poll,
+        token: Token,
+        interest: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()> {
+        let evented = EventedFd(&self.0);
+        evented.register(poll, token, interest, opts)
+    }
+
+    fn reregister(
+        &self,
+        poll: &Poll,
+        token: Token,
+        interest: Ready,
+        opts: PollOpt,
+    ) -> io::Result<()> {
+        let evented = EventedFd(&self.0);
+        evented.reregister(poll, token, interest, opts)
+    }
+
+    fn deregister(&self, poll: &Poll) -> io::Result<()> {
+        let evented = EventedFd(&self.0);
+        evented.deregister(poll)
+    }
+}
+
+impl Drop for TimerFd {
+    fn drop(&mut self) {
+        unsafe { libc::close(self.0) };
+    }
+}


### PR DESCRIPTION
EventedFd is an empty shell with no state that has access to private
mio::poll::register apis.

Fixes #4